### PR TITLE
Add scala 2.11, 2.13.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,24 +6,6 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
 
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,
@@ -36,13 +18,11 @@
 # CMake
 cmake-build-*/
 
-# Mongo Explorer plugin
-.idea/**/mongoSettings.xml
-
 # File-based project format
 *.iws
 
 # IntelliJ
+.idea
 out/
 
 # mpeltonen/sbt-idea plugin
@@ -51,17 +31,11 @@ out/
 # JIRA plugin
 atlassian-ide-plugin.xml
 
-# Cursive Clojure plugin
-.idea/replstate.xml
-
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
-
-# Editor-based Rest Client
-.idea/httpRequests
 
 ### Intellij Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
@@ -71,8 +45,6 @@ fabric.properties
 # .idea/misc.xml
 # *.ipr
 
-# Sonarlint plugin
-.idea/sonarlint
 
 ### SBT ###
 # Simple Build Tool

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: scala
 
 scala:
-- 2.12.6
+- 2.12.10
 
 script:
-- sbt test
+- sbt +test
 
 before_cache:
 - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,19 @@
 name := "util-backports"
 organization := "com.github.bigwheel"
-version := "2.0"
-scalaVersion := "2.12.6"
+version := "2.1"
+scalaVersion := "2.12.10"
+
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
+
+Compile / sources := {
+  scalaVersion.value match {
+    case CrossVersion.PartialVersion("2", "11" | "12") => (Compile / sources).value
+    case _ => Nil
+  }
+}
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.5" % Test
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test
 )
 
 // about maven publish

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.1
+sbt.version = 1.3.7


### PR DESCRIPTION
I'd love to use `Using` in my 2.11 cross builds, too, please!

I've also added an empty artifact for 2.13. Resolves #3.

```
unzip -t /Users/doug.roper/.ivy2/local/com.github.bigwheel/util-backports_2.13/2.1/jars/util-backports_2.13.jar
Archive:  /Users/doug.roper/.ivy2/local/com.github.bigwheel/util-backports_2.13/2.1/jars/util-backports_2.13.jar
    testing: META-INF/MANIFEST.MF     OK
No errors detected in compressed data of /Users/doug.roper/.ivy2/local/com.github.bigwheel/util-backports_2.13/2.1/jars/util-backports_2.13.jar.
```